### PR TITLE
Fix error in “Update Gutter” for non-UTF-8 encodings

### DIFF
--- a/Commands/Update Gutter on Save.tmCommand
+++ b/Commands/Update Gutter on Save.tmCommand
@@ -39,11 +39,9 @@ end
 added, changed = [ ], [ ]
 
 Dir.chdir(ENV['TM_PROJECT_DIRECTORY'] || ENV['TM_DIRECTORY'])
-open(diff_cmd) do |io|
+open(diff_cmd, 'r:ascii-8bit') do |io|
   in_block = false
   while line = io.gets
-     # `line` may contain non-UTF-8 characters if the document uses a non-UTF-8 encoding. To avoid runtime errors we can simply replace them (we're only interested in the diff markers at the beginning of `line` anyway, not its actual content).
-    line = line.encode('UTF-8', invalid: :replace)
     if line =~ /^@@ -(\d+),(\d+) \+(\d+),(\d+) @@/
       lineno   = $3.to_i
       deleted  = 0

--- a/Commands/Update Gutter on Save.tmCommand
+++ b/Commands/Update Gutter on Save.tmCommand
@@ -42,6 +42,8 @@ Dir.chdir(ENV['TM_PROJECT_DIRECTORY'] || ENV['TM_DIRECTORY'])
 open(diff_cmd) do |io|
   in_block = false
   while line = io.gets
+     # `line` may contain non-UTF-8 characters if the document uses a non-UTF-8 encoding. To avoid runtime errors we can simply replace them (we're only interested in the diff markers at the beginning of `line` anyway, not its actual content).
+    line = line.encode('UTF-8', invalid: :replace)
     if line =~ /^@@ -(\d+),(\d+) \+(\d+),(\d+) @@/
       lineno   = $3.to_i
       deleted  = 0


### PR DESCRIPTION
When the document uses an encoding different from UTF-8, the output of `diff_cmd` may contain characters that are not valid UTF-8. This leads to following error:

    Update Gutter:38:in `block in <main>': invalid byte sequence in UTF-8 (ArgumentError)
    	from Update Gutter:35:in `open'
    	from Update Gutter:35:in `<main>'

This is especially annoying because this error pops up every time the document is saved (because the “Update Gutter” command runs on every save).

A more “correct” approach would be to determine the document encoding and tell Ruby to use this encoding for `io`. But I’m not sure how to do this, and the code only looks at the diff markers at the beginning of lines anyway.